### PR TITLE
Update all references to database-js

### DIFF
--- a/examples/cloudflare/package-lock.json
+++ b/examples/cloudflare/package-lock.json
@@ -8,7 +8,7 @@
       "name": "f1-championship-stats",
       "version": "0.0.0",
       "dependencies": {
-        "@planetscale/database": "^1.0.1"
+        "@planetscale/database": "^1.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.14.1",
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@planetscale/database": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.0.1.tgz",
-      "integrity": "sha512-bAC2FqmhWu5hGiBtH4txAxwO6XeLCUzNr3ubMSso3AfCp5wp7Pw375ujtwZWpjCvpUhelu/X9em6bszPGTk5Bw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-5bGoY7HCJfzSjKUn/86Itn9jnD3I69Ta/J4iyOGA1DDEaWw3FzZ2+/xOiuzkOlq246/o7AVYdEaXTIm4yImRYg==",
       "engines": {
         "node": ">=16"
       }
@@ -1475,9 +1475,9 @@
       }
     },
     "@planetscale/database": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.0.1.tgz",
-      "integrity": "sha512-bAC2FqmhWu5hGiBtH4txAxwO6XeLCUzNr3ubMSso3AfCp5wp7Pw375ujtwZWpjCvpUhelu/X9em6bszPGTk5Bw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-5bGoY7HCJfzSjKUn/86Itn9jnD3I69Ta/J4iyOGA1DDEaWw3FzZ2+/xOiuzkOlq246/o7AVYdEaXTIm4yImRYg=="
     },
     "@types/stack-trace": {
       "version": "0.0.29",

--- a/examples/cloudflare/package.json
+++ b/examples/cloudflare/package.json
@@ -14,6 +14,6 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@planetscale/database": "^1.0.1"
+    "@planetscale/database": "^1.1"
   }
 }

--- a/examples/netlify/netlify/edge-functions/data.json.ts
+++ b/examples/netlify/netlify/edge-functions/data.json.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'https://edge.netlify.com'
-import { connect } from 'https://unpkg.com/@planetscale/database@^0.6.1'
+import { connect } from 'https://unpkg.com/@planetscale/database@^1.1'
 
 const CURRENT_YEAR = 2022
 

--- a/examples/netlify/package.json
+++ b/examples/netlify/package.json
@@ -14,6 +14,6 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@planetscale/database": "^1.0.1"
+    "@planetscale/database": "^1.1"
   }
 }

--- a/examples/vercel/package-lock.json
+++ b/examples/vercel/package-lock.json
@@ -8,7 +8,7 @@
       "name": "f1-championship-stats",
       "version": "0.0.0",
       "dependencies": {
-        "@planetscale/database": "^1.0.1"
+        "@planetscale/database": "^1.1"
       },
       "devDependencies": {
         "@planetscale/core-prettier": "^1.0.1",
@@ -115,9 +115,9 @@
       "dev": true
     },
     "node_modules/@planetscale/database": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.0.1.tgz",
-      "integrity": "sha512-bAC2FqmhWu5hGiBtH4txAxwO6XeLCUzNr3ubMSso3AfCp5wp7Pw375ujtwZWpjCvpUhelu/X9em6bszPGTk5Bw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-5bGoY7HCJfzSjKUn/86Itn9jnD3I69Ta/J4iyOGA1DDEaWw3FzZ2+/xOiuzkOlq246/o7AVYdEaXTIm4yImRYg==",
       "engines": {
         "node": ">=16"
       }
@@ -2751,9 +2751,9 @@
       "dev": true
     },
     "@planetscale/database": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.0.1.tgz",
-      "integrity": "sha512-bAC2FqmhWu5hGiBtH4txAxwO6XeLCUzNr3ubMSso3AfCp5wp7Pw375ujtwZWpjCvpUhelu/X9em6bszPGTk5Bw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@planetscale/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-5bGoY7HCJfzSjKUn/86Itn9jnD3I69Ta/J4iyOGA1DDEaWw3FzZ2+/xOiuzkOlq246/o7AVYdEaXTIm4yImRYg=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/examples/vercel/package.json
+++ b/examples/vercel/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@planetscale/database": "^1.0.1"
+    "@planetscale/database": "^1.1"
   },
   "devDependencies": {
     "@planetscale/core-prettier": "^1.0.1",


### PR DESCRIPTION
At least bump them all to the same version, so they're consistent
everywhere, which will make it easier to bump them all with a script or
at least to grep.

I also loosened the spec since there's no reason to be so strict.